### PR TITLE
add missing include for std::optional

### DIFF
--- a/rcss3d_agent/src/sexp_vision.hpp
+++ b/rcss3d_agent/src/sexp_vision.hpp
@@ -15,6 +15,7 @@
 #ifndef SEXP_VISION_HPP_
 #define SEXP_VISION_HPP_
 
+#include <optional>
 #include <vector>
 #include "rcss3d_agent_msgs/msg/ball.hpp"
 #include "rcss3d_agent_msgs/msg/field_line.hpp"


### PR DESCRIPTION
I'm not sure why this isn't necessary for building on Ubuntu, but this missing include caused this package to regress building on RHEL in ROS Galactic: https://build.ros2.org/view/Gbin_rhel_el864/job/Gbin_rhel_el864__rcss3d_agent__rhel_8_x86_64__binary/

```
In file included from /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/sexp_vision.cpp:18:
00:01:30.396 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/./sexp_vision.hpp:32:6: error: 'optional' in namespace 'std' does not name a template type
00:01:30.396 DEBUG:  std::optional<rcss3d_agent_msgs::msg::Ball> getBall(sexpresso::Sexp & seeSexp);
00:01:30.396 DEBUG:       ^~~~~~~~
00:01:30.396 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/./sexp_vision.hpp:32:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
00:01:30.396 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/./sexp_vision.hpp:24:1:
00:01:30.396 DEBUG: +#include <optional>
00:01:30.396 DEBUG:  
00:01:30.396 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/./sexp_vision.hpp:32:1:
00:01:30.396 DEBUG:  std::optional<rcss3d_agent_msgs::msg::Ball> getBall(sexpresso::Sexp & seeSexp);
00:01:30.396 DEBUG:  ^~~
00:01:30.397 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/sexp_vision.cpp:28:6: error: 'optional' in namespace 'std' does not name a template type
00:01:30.397 DEBUG:  std::optional<rcss3d_agent_msgs::msg::Ball> getBall(sexpresso::Sexp & seeSexp)
00:01:30.398 DEBUG:       ^~~~~~~~
00:01:30.398 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/sexp_vision.cpp:28:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
00:01:30.398 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/sexp_vision.cpp:22:1:
00:01:30.398 DEBUG: +#include <optional>
00:01:30.398 DEBUG:  
00:01:30.399 DEBUG: /builddir/build/BUILD/ros-galactic-rcss3d-agent-0.0.3/src/sexp_vision.cpp:28:1:
00:01:30.399 DEBUG:  std::optional<rcss3d_agent_msgs::msg::Ball> getBall(sexpresso::Sexp & seeSexp)
00:01:30.399 DEBUG:  ^~~
```

I'm planning to sync Galactic next week. If we don't have a fix released by then, the sync will remove rcss3d_agent for RHEL. 

The Ubuntu package is building fine and is unaffected: https://build.ros2.org/job/Gbin_uF64__rcss3d_agent__ubuntu_focal_amd64__binary/